### PR TITLE
Switch Uniprot URLs to HTTPS and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # cyanobacteria-diazotrophic-proteome
-Comparative bioinformatics to elucidate target proteins for diazotrophic function
+
+This repository contains a Snakemake workflow for collecting cyanobacterial proteomes,
+building an all-vs-all BLAST database, clustering orthologs, annotating with
+InterProScan, and running enrichment analysis.
+
+## Usage
+
+1. Create and activate the conda environment:
+
+```bash
+mamba env create -f environment.yaml -n cyano-diazotroph
+conda activate cyano-diazotroph
+```
+
+2. Run the workflow (adjust `--cores` as appropriate):
+
+```bash
+snakemake --cores 16
+```
+
+To only fetch the raw FASTA files you can run:
+
+```bash
+snakemake data/raw/.download_complete
+```
+
+The Uniprot proteome links use HTTPS. If you encounter download issues,
+verify the URLs in `species.yaml`.

--- a/species.yaml
+++ b/species.yaml
@@ -6,12 +6,12 @@ filamentous_diazotrophic:
 
 unicellular_diazotrophic:
   - name: crocosphaera_subtropica_atcc51142
-    url: ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/proteomes/UP000001203/UP000001203.fasta.gz
+    url: https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/proteomes/UP000001203/UP000001203.fasta.gz
 
 filamentous_non_diazotrophic:
   - name: arthrospira_platensis_nies39
-    url: ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/proteomes/UP000006803/UP000006803.fasta.gz
+    url: https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/proteomes/UP000006803/UP000006803.fasta.gz
 
 unicellular_non_diazotrophic:
   - name: synechocystis_sp_pcc6803
-    url: ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/proteomes/UP000009640/UP000009640.fasta.gz
+    url: https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/proteomes/UP000009640/UP000009640.fasta.gz


### PR DESCRIPTION
## Summary
- document how to set up the environment and run the workflow
- switch Uniprot download links to HTTPS so downloads succeed when FTP is unavailable

## Testing
- `python3 -m py_compile scripts/*.py`