### PR TITLE
Add blast filtering step

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ python3 scripts/cluster_size_distribution.py
 
 The Uniprot proteome links use HTTPS. If you encounter download issues,
 verify the URLs in `species.yaml`.
+
+### Adjusting BLAST filtering
+
+The workflow now keeps the raw BLAST results and allows filtering by
+percent identity and e-value prior to clustering. Default thresholds are
+40% identity and `1e-10` for the e-value. You can tweak these by editing
+the `filter_blast_hits` rule in the `Snakefile` or running the filtering
+utility directly:
+
+```bash
+scripts/filter_blast_hits.py results/blastp/blastp_all.out \
+    results/blastp/blastp_filtered.out --pident 50 --evalue 1e-20
+```

--- a/Snakefile
+++ b/Snakefile
@@ -53,12 +53,26 @@ rule run_blastp:
     shell:
         "scripts/03_run_blastp.sh"
 
+rule filter_blast_hits:
+    """
+    Filter BLAST hits by percent identity and e-value.
+    """
+    input:
+        "results/blastp/blastp_all.out"
+    output:
+        "results/blastp/blastp_filtered.out"
+    params:
+        pident=40,
+        evalue=1e-10
+    shell:
+        "scripts/filter_blast_hits.py {input} {output} --pident {params.pident} --evalue {params.evalue}"
+
 rule cluster_orthologs:
     """
     Filter the BLAST hits and cluster with MCL into ortholog groups.
     """
     input:
-        "results/blastp/blastp_all.out"
+        "results/blastp/blastp_filtered.out"
     output:
         clusters="results/clusters/clusters.txt",
         mapping="results/clusters/clusters_mapping.tsv"

--- a/scripts/03_run_blastp.sh
+++ b/scripts/03_run_blastp.sh
@@ -10,7 +10,7 @@ blastp \
   -query data/db/all_cyano.faa \
   -evalue 1e-5 \
   -num_threads $CPU \
-  -outfmt "6 qseqid sseqid pident length qlen slen" \
+  -outfmt "6 qseqid sseqid pident length qlen slen evalue" \
   -out results/blastp/blastp_all.out
 
 echo "[DONE] blastp_all.out"

--- a/scripts/04_cluster_orthologs.R
+++ b/scripts/04_cluster_orthologs.R
@@ -2,7 +2,7 @@
 library(data.table)
 
 # Paths
-blast_file   <- "results/blastp/blastp_all.out"
+blast_file   <- "results/blastp/blastp_filtered.out"
 out_dir      <- "results/clusters"
 mcl_input    <- file.path(out_dir, "blast.mci")
 clusters_txt <- file.path(out_dir, "clusters.txt")
@@ -11,7 +11,7 @@ mapping_tsv  <- file.path(out_dir, "clusters_mapping.tsv")
 dir.create(out_dir, recursive=TRUE, showWarnings=FALSE)
 
 # 1) Read and filter BLAST hits
-cols <- c("qseqid","sseqid","pident","length","qlen","slen")
+cols <- c("qseqid","sseqid","pident","length","qlen","slen","evalue")
 blast <- fread(blast_file, header=FALSE, col.names=cols)
 
 filtered <- blast[

--- a/scripts/filter_blast_hits.py
+++ b/scripts/filter_blast_hits.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Filter BLAST tabular output by percent identity and e-value."""
+import argparse
+import pandas as pd
+
+# CLI
+parser = argparse.ArgumentParser(description="Filter BLAST hits")
+parser.add_argument("input", help="BLAST tabular file")
+parser.add_argument("output", help="Filtered output path")
+parser.add_argument("--pident", type=float, default=40.0, help="Minimum percent identity")
+parser.add_argument("--evalue", type=float, default=1e-10, help="Maximum e-value")
+args = parser.parse_args()
+
+cols = ["qseqid","sseqid","pident","length","qlen","slen","evalue"]
+
+df = pd.read_csv(args.input, sep="\t", header=None, names=cols)
+
+filt = df[(df.pident >= args.pident) & (df.evalue <= args.evalue)]
+
+filt.to_csv(args.output, sep="\t", header=False, index=False)


### PR DESCRIPTION
## Summary
- output e-values from blastp results
- introduce `filter_blast_hits.py` for customizable blast filtering
- hook filtering step into the workflow via new `filter_blast_hits` rule
- run clustering on the filtered results
- document how to adjust filtering thresholds

## Testing
- `python3 -m py_compile scripts/filter_blast_hits.py`
- `snakemake -n` *(fails: command not found)*