### PR TITLE
Fix species prefix extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ scripts/filter_blast_hits.py results/blastp/blastp_all.out \
     results/blastp/blastp_filtered.out --pident 50 --evalue 1e-20
 ```
 
+The BLAST database is built from all downloaded FASTA files with each
+sequence header prefixed by its species name (taken from `species.yaml`).
+Downstream scripts rely on this convention to map proteins back to their
+source species.
+
 ### Identifying diazotroph-specific proteins
 
 If you only want the BLAST search and a list of proteins that lack hits in non-diazotrophic genomes, run the workflow up to the filtering step:

--- a/scripts/02_build_blast_db.sh
+++ b/scripts/02_build_blast_db.sh
@@ -2,7 +2,21 @@
 set -euo pipefail
 
 mkdir -p data/db
-cat data/raw/*/*.faa > data/db/all_cyano.faa
+
+# Build concatenated FASTA with species prefixes so downstream scripts can
+# recover the species name from sequence IDs. Each sequence header is rewritten
+# as ">speciesID_originalHeader" where "speciesID" comes from the FASTA file name.
+> data/db/all_cyano.faa
+for faa in data/raw/*/*.faa; do
+    sp=$(basename "$faa" .faa)
+    awk -v pre="${sp}_" '{
+        if(substr($0,1,1)==">") {
+            print ">" pre substr($0,2)
+        } else {
+            print
+        }
+    }' "$faa" >> data/db/all_cyano.faa
+done
 
 echo "[MAKEBLASTDB] building protein DB…"
 makeblastdb \

--- a/scripts/find_unique_proteins.py
+++ b/scripts/find_unique_proteins.py
@@ -32,9 +32,22 @@ non_diazo_species = [e["name"] for g in non_diazo_groups for e in cfg[g]]
 cols = ["qseqid","sseqid","pident","length","qlen","slen","evalue"]
 hits = pd.read_csv(args.blast, sep="\t", header=None, names=cols)
 
-# Extract species names (assumes FASTA headers start with species name followed by '_')
-hits["q_species"] = hits["qseqid"].str.split("_").str[0]
-hits["s_species"] = hits["sseqid"].str.split("_").str[0]
+# Extract species names by matching known prefixes. FASTA headers were
+# rewritten as "speciesID_originalHeader" when building the BLAST database,
+# but species IDs themselves contain underscores, so we can't simply split on
+# the first underscore. Instead, match against the full list of species
+# prefixes from ``species.yaml``.
+all_species = sorted(diazo_species + non_diazo_species, key=len, reverse=True)
+
+def extract_species(seqid: str) -> str:
+    for sp in all_species:
+        if seqid.startswith(f"{sp}_"):
+            return sp
+    # Fallback: just take the portion before the first underscore
+    return seqid.split("_")[0]
+
+hits["q_species"] = hits["qseqid"].apply(extract_species)
+hits["s_species"] = hits["sseqid"].apply(extract_species)
 
 # Hits from diazotroph queries to non-diazotroph subjects
 hits_d2n = hits[hits["q_species"].isin(diazo_species) & hits["s_species"].isin(non_diazo_species)]


### PR DESCRIPTION
## Summary
- handle underscores in species IDs when extracting names from BLAST results

## Testing
- `python3 -m py_compile scripts/*.py`
- `bash -n scripts/02_build_blast_db.sh`
- `bash -n scripts/03_run_blastp.sh`
- `bash -n scripts/06_annotate_interpro.sh`
