### PR TITLE
Fix species name parsing for unique protein script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ scripts/filter_blast_hits.py results/blastp/blastp_all.out \
     results/blastp/blastp_filtered.out --pident 50 --evalue 1e-20
 ```
 
+The BLAST database is built from all downloaded FASTA files with each
+sequence header prefixed by its species name (taken from `species.yaml`).
+Downstream scripts rely on this convention to map proteins back to their
+source species.
+
 ### Identifying diazotroph-specific proteins
 
 If you only want the BLAST search and a list of proteins that lack hits in non-diazotrophic genomes, run the workflow up to the filtering step:

--- a/scripts/02_build_blast_db.sh
+++ b/scripts/02_build_blast_db.sh
@@ -2,7 +2,21 @@
 set -euo pipefail
 
 mkdir -p data/db
-cat data/raw/*/*.faa > data/db/all_cyano.faa
+
+# Build concatenated FASTA with species prefixes so downstream scripts can
+# recover the species name from sequence IDs. Each sequence header is rewritten
+# as ">speciesID_originalHeader" where "speciesID" comes from the FASTA file name.
+> data/db/all_cyano.faa
+for faa in data/raw/*/*.faa; do
+    sp=$(basename "$faa" .faa)
+    awk -v pre="${sp}_" '{
+        if(substr($0,1,1)==">") {
+            print ">" pre substr($0,2)
+        } else {
+            print
+        }
+    }' "$faa" >> data/db/all_cyano.faa
+done
 
 echo "[MAKEBLASTDB] building protein DB…"
 makeblastdb \


### PR DESCRIPTION
## Summary
- handle species IDs that contain underscores when parsing BLAST results

## Testing
- `python3 -m py_compile scripts/*.py`
- `bash -n scripts/02_build_blast_db.sh`
- `bash -n scripts/03_run_blastp.sh`
- `bash -n scripts/06_annotate_interpro.sh`
