### PR TITLE
Enhance cohort tables with per-species details

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -14,7 +14,10 @@ rule all:
     input:
         "results/cohorts/unicellular_specific.tsv",
         "results/cohorts/filamentous_specific.tsv",
-        "results/cohorts/diazotroph_common.tsv"
+        "results/cohorts/diazotroph_common.tsv",
+        "results/cohorts/unicellular_specific.csv",
+        "results/cohorts/filamentous_specific.csv",
+        "results/cohorts/diazotroph_common.csv"
 
 rule download_proteomes:
     """
@@ -75,9 +78,12 @@ rule identify_cohorts:
     input:
         "results/blastp/blastp_filtered.out"
     output:
-        uni="results/cohorts/unicellular_specific.tsv",
-        fil="results/cohorts/filamentous_specific.tsv",
-        common="results/cohorts/diazotroph_common.tsv"
+        uni_tsv="results/cohorts/unicellular_specific.tsv",
+        fil_tsv="results/cohorts/filamentous_specific.tsv",
+        common_tsv="results/cohorts/diazotroph_common.tsv",
+        uni_csv="results/cohorts/unicellular_specific.csv",
+        fil_csv="results/cohorts/filamentous_specific.csv",
+        common_csv="results/cohorts/diazotroph_common.csv"
     shell:
         "scripts/identify_cohorts.py {input} results/cohorts"
 

--- a/scripts/identify_cohorts.py
+++ b/scripts/identify_cohorts.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Identify diazotroph protein cohorts from filtered BLAST hits."""
+"""Identify diazotroph protein cohorts from filtered BLAST hits.
+
+The output tables now report, for every query sequence in each cohort,
+how many hits were observed to non‑diazotrophic species as well as the
+best hit identity and accession for every species configured in
+``species.yaml``.  Tables are written both as TSV and CSV files.
+"""
 import argparse
 import pandas as pd
 import yaml
@@ -43,6 +49,9 @@ hits = pd.read_csv(args.blast, sep="\t", header=None, names=cols)
 hits["q_species"] = hits["qseqid"].apply(extract_species)
 hits["s_species"] = hits["sseqid"].apply(extract_species)
 
+# Ordered list of all species for table columns
+species_order = [e["name"] for grp in cfg.values() for e in grp]
+
 cohort_uni = []
 cohort_fil = []
 cohort_all = []
@@ -51,23 +60,47 @@ for qseqid, grp in hits.groupby("qseqid"):
     q_sp = grp["q_species"].iloc[0]
     target_species = set(grp["s_species"]) - {q_sp}
 
+    row = {"qseqid": qseqid}
+    row["non_diazotroph_hits"] = int(grp[grp["s_species"].isin(non_diazo)].shape[0])
+
+    for sp in species_order:
+        sub = grp[grp["s_species"] == sp]
+        if sub.empty:
+            row[f"{sp}_pident"] = 0
+            row[f"{sp}_acc"] = ""
+        else:
+            best = sub.loc[sub["pident"].idxmax()]
+            row[f"{sp}_pident"] = best["pident"]
+            row[f"{sp}_acc"] = best["sseqid"]
+
     if q_sp in all_diazo:
-        if (all_diazo - {q_sp}).issubset(target_species) \
-                and target_species.isdisjoint(non_diazo):
-            cohort_all.append(qseqid)
+        if (all_diazo - {q_sp}).issubset(target_species):
+            cohort_all.append(row)
 
     if q_sp in unicell_diazo:
         required = set(unicell_diazo) - {q_sp}
-        if required.issubset(target_species) \
-                and target_species.isdisjoint(set(fil_diazo + non_diazo)):
-            cohort_uni.append(qseqid)
+        if required.issubset(target_species) and target_species.isdisjoint(set(fil_diazo)):
+            cohort_uni.append(row)
 
     if q_sp in fil_diazo:
         required = set(fil_diazo) - {q_sp}
-        if required.issubset(target_species) \
-                and target_species.isdisjoint(set(unicell_diazo + non_diazo)):
-            cohort_fil.append(qseqid)
+        if required.issubset(target_species) and target_species.isdisjoint(set(unicell_diazo)):
+            cohort_fil.append(row)
 
-pd.Series(sorted(cohort_uni)).to_csv(os.path.join(args.output_dir, "unicellular_specific.tsv"), index=False, header=False)
-pd.Series(sorted(cohort_fil)).to_csv(os.path.join(args.output_dir, "filamentous_specific.tsv"), index=False, header=False)
-pd.Series(sorted(cohort_all)).to_csv(os.path.join(args.output_dir, "diazotroph_common.tsv"), index=False, header=False)
+def write_tables(rows, basename):
+    if not rows:
+        df = pd.DataFrame(columns=["qseqid", "non_diazotroph_hits"] +
+                               [f"{sp}_pident" for sp in species_order] +
+                               [f"{sp}_acc" for sp in species_order])
+    else:
+        df = pd.DataFrame(rows)
+        df = df.sort_values("qseqid")
+
+    tsv_path = os.path.join(args.output_dir, basename + ".tsv")
+    csv_path = os.path.join(args.output_dir, basename + ".csv")
+    df.to_csv(tsv_path, sep="\t", index=False)
+    df.to_csv(csv_path, index=False)
+
+write_tables(cohort_uni, "unicellular_specific")
+write_tables(cohort_fil, "filamentous_specific")
+write_tables(cohort_all, "diazotroph_common")


### PR DESCRIPTION
## Summary
- keep diazotroph queries even when they hit non-diazotrophs
- store number of non-diazotroph hits and best hit info per species
- output cohort summaries as TSV and CSV

## Testing
- `python3 -m py_compile scripts/*.py`
- `bash -n scripts/*.sh`
- `snakemake -n` *(fails: command not found)*