### PR TITLE
Add diazotroph hit counts and group average identity

### DIFF
--- a/scripts/identify_cohorts.py
+++ b/scripts/identify_cohorts.py
@@ -2,9 +2,13 @@
 """Identify diazotroph protein cohorts from filtered BLAST hits.
 
 The output tables now report, for every query sequence in each cohort,
-how many hits were observed to non‑diazotrophic species as well as the
-best hit identity and accession for every species configured in
-``species.yaml``.  Tables are written both as TSV and CSV files.
+how many hits were observed to each major species group. In addition to
+``non_diazotroph_hits`` the tables now include ``diazotroph_hits``,
+``unicellular_diazotroph_hits`` and ``filamentous_diazotroph_hits``.
+For each table the average percent identity across the relevant group is
+reported in the ``avg_group_pident`` column. The best hit identity and
+accession for every species configured in ``species.yaml`` are also
+included. Tables are written both as TSV and CSV files.
 """
 import argparse
 import pandas as pd
@@ -62,6 +66,9 @@ for qseqid, grp in hits.groupby("qseqid"):
 
     row = {"qseqid": qseqid}
     row["non_diazotroph_hits"] = int(grp[grp["s_species"].isin(non_diazo)].shape[0])
+    row["diazotroph_hits"] = int(grp[grp["s_species"].isin(all_diazo)].shape[0])
+    row["unicellular_diazotroph_hits"] = int(grp[grp["s_species"].isin(unicell_diazo)].shape[0])
+    row["filamentous_diazotroph_hits"] = int(grp[grp["s_species"].isin(fil_diazo)].shape[0])
 
     for sp in species_order:
         sub = grp[grp["s_species"] == sp]
@@ -72,6 +79,15 @@ for qseqid, grp in hits.groupby("qseqid"):
             best = sub.loc[sub["pident"].idxmax()]
             row[f"{sp}_pident"] = best["pident"]
             row[f"{sp}_acc"] = best["sseqid"]
+
+    def avg_for(group):
+        members = [sp for sp in group if sp != q_sp]
+        vals = [row[f"{sp}_pident"] for sp in members]
+        return sum(vals) / len(vals) if vals else 0.0
+
+    row["avg_pident_unicellular"] = avg_for(unicell_diazo)
+    row["avg_pident_filamentous"] = avg_for(fil_diazo)
+    row["avg_pident_diazotroph"] = avg_for(all_diazo)
 
     if q_sp in all_diazo:
         if (all_diazo - {q_sp}).issubset(target_species):
@@ -87,20 +103,37 @@ for qseqid, grp in hits.groupby("qseqid"):
         if required.issubset(target_species) and target_species.isdisjoint(set(unicell_diazo)):
             cohort_fil.append(row)
 
-def write_tables(rows, basename):
+def write_tables(rows, basename, avg_col):
+    base_cols = [
+        "qseqid",
+        "non_diazotroph_hits",
+        "diazotroph_hits",
+        "unicellular_diazotroph_hits",
+        "filamentous_diazotroph_hits",
+        "avg_group_pident",
+    ]
     if not rows:
-        df = pd.DataFrame(columns=["qseqid", "non_diazotroph_hits"] +
-                               [f"{sp}_pident" for sp in species_order] +
-                               [f"{sp}_acc" for sp in species_order])
+        df = pd.DataFrame(
+            columns=base_cols
+            + [f"{sp}_pident" for sp in species_order]
+            + [f"{sp}_acc" for sp in species_order]
+        )
     else:
         df = pd.DataFrame(rows)
         df = df.sort_values("qseqid")
+        df = df.rename(columns={avg_col: "avg_group_pident"})
+        drop_cols = {
+            "avg_pident_unicellular",
+            "avg_pident_filamentous",
+            "avg_pident_diazotroph",
+        } - {avg_col}
+        df = df.drop(columns=list(drop_cols))
 
     tsv_path = os.path.join(args.output_dir, basename + ".tsv")
     csv_path = os.path.join(args.output_dir, basename + ".csv")
     df.to_csv(tsv_path, sep="\t", index=False)
     df.to_csv(csv_path, index=False)
 
-write_tables(cohort_uni, "unicellular_specific")
-write_tables(cohort_fil, "filamentous_specific")
-write_tables(cohort_all, "diazotroph_common")
+write_tables(cohort_uni, "unicellular_specific", "avg_pident_unicellular")
+write_tables(cohort_fil, "filamentous_specific", "avg_pident_filamentous")
+write_tables(cohort_all, "diazotroph_common", "avg_pident_diazotroph")


### PR DESCRIPTION
## Summary
- expand identify_cohorts output to record hits to diazotrophic groups
- compute average percent identity for the cohort of interest
- update docs in script

## Testing
- `python -m py_compile scripts/identify_cohorts.py`