### PR TITLE
Allow cohort rows with cross-group hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ different groups of diazotrophs.  The final output consists of three lists of
 protein accessions describing the cohorts illustrated below:
 
 1. `unicellular_specific.tsv` – proteins present in all unicellular diazotrophic
-   cyanobacteria but absent from filamentous diazotrophs and non‑diazotrophs.
+   cyanobacteria. Hits to filamentous diazotrophs may also be reported and can
+   be filtered out downstream if desired.
 2. `filamentous_specific.tsv` – proteins conserved across filamentous
-   diazotrophic cyanobacteria but missing from unicellular diazotrophs and
-   non‑diazotrophs.
+   diazotrophic cyanobacteria. Hits to unicellular diazotrophs may likewise be
+   included.
 3. `diazotroph_common.tsv` – proteins found in both unicellular and filamentous
-   diazotrophic species but absent from non‑diazotrophic cyanobacteria.
+   diazotrophic species while absent from non‑diazotrophic cyanobacteria.
 
 ## Usage
 

--- a/scripts/identify_cohorts.py
+++ b/scripts/identify_cohorts.py
@@ -95,12 +95,12 @@ for qseqid, grp in hits.groupby("qseqid"):
 
     if q_sp in unicell_diazo:
         required = set(unicell_diazo) - {q_sp}
-        if required.issubset(target_species) and target_species.isdisjoint(set(fil_diazo)):
+        if required.issubset(target_species):
             cohort_uni.append(row)
 
     if q_sp in fil_diazo:
         required = set(fil_diazo) - {q_sp}
-        if required.issubset(target_species) and target_species.isdisjoint(set(unicell_diazo)):
+        if required.issubset(target_species):
             cohort_fil.append(row)
 
 def write_tables(rows, basename, avg_col):


### PR DESCRIPTION
## Summary
- don't drop hits from the opposite diazotroph group when assigning protein cohorts
- note the relaxed cohorting criteria in the README

## Testing
- `python -m py_compile scripts/identify_cohorts.py`